### PR TITLE
Fix building with GHC 7.2.1.

### DIFF
--- a/UI/HSCurses/Curses.hsc
+++ b/UI/HSCurses/Curses.hsc
@@ -745,13 +745,13 @@ attrBold = (#const A_BOLD)
 
 ------------------------------------------------------------------------
 
-foreign import ccall threadsafe
+foreign import ccall safe
     waddch :: Window -> ChType -> IO CInt
 
-foreign import ccall threadsafe
+foreign import ccall safe
     waddchnstr :: Window -> CString -> CInt -> IO CInt
 
-foreign import ccall threadsafe "static curses.h mvaddch" mvaddch_c :: CInt -> CInt -> ChType -> IO ()
+foreign import ccall safe "static curses.h mvaddch" mvaddch_c :: CInt -> CInt -> ChType -> IO ()
 
 mvWAddStr :: Window -> Int -> Int -> String -> IO ()
 mvWAddStr w y x str = wMove w y x >> wAddStr w str
@@ -828,12 +828,12 @@ wAddStr _   [] = return ()
 wAddStr win s  = throwIfErr_ ("waddnstr: <" ++ s ++ ">") $
     withLCStringLen (s) (\(ws,len) -> waddnstr win ws (fi len))
 
-foreign import ccall threadsafe
+foreign import ccall safe
     waddnstr :: Window -> CString -> CInt -> IO CInt
 
 #endif
 
-foreign import ccall threadsafe
+foreign import ccall safe
     vline  :: Char -> Int -> IO ()
 
 ------------------------------------------------------------------------

--- a/hscurses.cabal
+++ b/hscurses.cabal
@@ -1,5 +1,5 @@
 Name:           hscurses
-Version:        1.4.0.0
+Version:        1.4.1.0
 License:        LGPL
 License-file:   LICENSE
 Author:         John Meacham <john at repetae dot net>
@@ -22,7 +22,7 @@ Description:
 Homepage:       https://github.com/skogsbaer/hscurses
 Cabal-version: >= 1.6
 Build-Type:     Configure
-Tested-with:    GHC==6.12.1, GHC==7.0.1
+Tested-with:    GHC==6.12.1, GHC==7.0.1, GHC==7.2.1
 Data-files:
     README, TODO, ChangeLog,
     example/contacts2, example/Setup.hs, example/ContactManager.hs,
@@ -31,7 +31,7 @@ Data-files:
     cbits/HSCurses.h, cbits/HSCursesUtils.h
 
 Library
-  Build-depends:  base == 4.*, unix == 2.4.*, mtl,
+  Build-depends:  base == 4.*, unix >= 2.4 && < 2.6, mtl,
                   old-time == 1.0.*, old-locale == 1.0.*
   Exposed-modules:
       UI.HSCurses.Curses, UI.HSCurses.CursesHelper, UI.HSCurses.Widgets,


### PR DESCRIPTION
The 'threadsafe' foreign modifier was finally removed, and the unix
dependency needed to be relaxed a bit. Should build fine on 7.0.x
and 7.2.x now.
