### PR TITLE
Extend defineKey definition 

### DIFF
--- a/UI/HSCurses/Curses.hsc
+++ b/UI/HSCurses/Curses.hsc
@@ -234,6 +234,11 @@ resetParams = do
     defineKey (#const KEY_DOWN) "\x1b[1;2B"
     defineKey (#const KEY_SLEFT) "\x1b[1;2D"
     defineKey (#const KEY_SRIGHT) "\x1b[1;2C"
+    defineKey (#const KEY_B2) "\x1b[E"  -- xterm seems to emit B2, not BEG
+    defineKey (#const KEY_END) "\x1b[F"
+    defineKey (#const KEY_END) "\x1b[4~"
+    defineKey (#const KEY_HOME) "\x1b[H"
+    defineKey (#const KEY_HOME) "\x1b[1~"
 #endif
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Now it covers all number keys on the numerical keypad under Gnome Terminal
with NumLock off, both with Shift and without. Works correctly on my machine.

I'm aware this package is not the right place to fix faulty terminfo databases, curses versions, terminal emulators and their interactions thereof. Still, this little patch makes the game Allure run without problems in Gnome Terminal and there is a justified hope this hack will also help others (see #9 for discussion).

The commit mostly mimics this one:

https://github.com/coreyoconnor/vty/commit/93b8f8e64c0c027b817dfa96959f02976390fc53

and the data was taken from here

http://audit.sourcearchive.com/documentation/1.7.13/tty__named__keys_8h-source.html

and there

http://www.geocities.jp/sakachin2/xehelp/html/HID00000579.htm
