### PR TITLE
fix for ghc 7.8

### DIFF
--- a/hscurses.cabal
+++ b/hscurses.cabal
@@ -38,7 +38,7 @@ Library
   Build-depends:  base == 4.*, mtl,
                   old-time < 1.2, old-locale == 1.0.*
   if !os(windows)
-    Build-depends: unix >= 2.4 && < 2.7
+    Build-depends: unix >= 2.4 && < 2.8
   Exposed-modules:
       UI.HSCurses.Curses, UI.HSCurses.CursesHelper, UI.HSCurses.Widgets,
       UI.HSCurses.MonadException, UI.HSCurses.Logging


### PR DESCRIPTION
- allow unix version 2.7.*
- use mask instead of block/unblock in MonadException
