### PR TITLE
base lower bound to >=4.4

### DIFF
--- a/hscurses.cabal
+++ b/hscurses.cabal
@@ -35,7 +35,7 @@ Source-Repository head
   Location:       git://github.com/skogsbaer/hscurses.git
 
 Library
-  Build-depends:  base == 4.*, exceptions, mtl,
+  Build-depends:  base >=4.4 && <5, exceptions, mtl,
                   old-time < 1.2, old-locale == 1.0.*
   Extra-libraries: curses
   if !os(windows)


### PR DESCRIPTION
based on http://matrix.hackage.haskell.org/package/hscurses

I'll also recommend to setup travis builds, it's easy using script from https://github.com/hvr/multi-ghc-travis.
