### PR TITLE
Update logging dependencies and make it usable from "outside"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ through Haddock API documentation.
 For basic usage check out the code in the [example](./example) and
 [./tests](tests) directories.
 
+### Debug logging
+
+`hscurses` ships with very basic logging functionality. The default behavior is
+not to compile with support for this, but you can use the Cabal flag `debug` to
+manually enable this. Logs will be written to `.hscurses.logs` in the directory
+you're running the `cabal` command from. Example:
+
+    cabal run -f examples -f debug contact-manager -- example/contacts
+
 ## Windows support
 
 Windows support relies on [pdcurses](http://pdcurses.sourceforge.net/), which is

--- a/UI/HSCurses/Logging.hs
+++ b/UI/HSCurses/Logging.hs
@@ -20,9 +20,7 @@ module UI.HSCurses.Logging (trace,debug) where
 
 import Control.Monad.Trans
 
-#define __DEBUG__ 0
-
-#if __DEBUG__
+#if DEBUG
 
 import System.IO
 import System.IO.Unsafe (unsafePerformIO)
@@ -30,11 +28,10 @@ import qualified Data.Time as Time
 
 #endif
 
-
 trace :: String -> a -> a
 debug :: MonadIO m => String -> m ()
 
-#if __DEBUG__
+#if DEBUG
 
 logFile :: Handle
 logFile = unsafePerformIO $ do h <- openFile ".hscurses.log" AppendMode

--- a/hscurses.cabal
+++ b/hscurses.cabal
@@ -43,6 +43,11 @@ Flag examples
   Default:        False
   Manual:         True
 
+Flag debug
+  Description:    Compile with logging/tracing functions
+  Default:        False
+  Manual:         True
+
 Library
   Build-depends:  base == 4.*
                 , exceptions < 0.11
@@ -51,6 +56,8 @@ Library
   Extra-libraries: curses
   If !os(windows)
     Build-depends: unix < 2.9
+  If flag(debug)
+    Cpp-options: -DDEBUG=1
   Exposed-modules:
       UI.HSCurses.Curses, UI.HSCurses.CursesHelper, UI.HSCurses.Widgets,
       UI.HSCurses.Logging

--- a/hscurses.cabal
+++ b/hscurses.cabal
@@ -44,11 +44,13 @@ Flag examples
   Manual:         True
 
 Library
-  Build-depends:  base == 4.*, exceptions, mtl,
-                  old-time < 1.2, old-locale == 1.0.*
+  Build-depends:  base == 4.*
+                , exceptions < 0.11
+                , mtl < 2.4
+                , time < 1.13
   Extra-libraries: curses
-  if !os(windows)
-    Build-depends: unix >= 2.4
+  If !os(windows)
+    Build-depends: unix < 2.9
   Exposed-modules:
       UI.HSCurses.Curses, UI.HSCurses.CursesHelper, UI.HSCurses.Widgets,
       UI.HSCurses.Logging


### PR DESCRIPTION
- Replace `old-time` and `old-locale` with `time`
- Add a Cabal flag `debug` that is now usable for library users to enable logging/tracing