### PR TITLE
Proposal: Ord instances for Key and ButtonEvent.

### DIFF
--- a/UI/HSCurses/Curses.hsc
+++ b/UI/HSCurses/Curses.hsc
@@ -1254,7 +1254,7 @@ data Key
     | KeyResize
     | KeyMouse
     | KeyUnknown Int
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 decodeKey :: CInt -> Key
 decodeKey key = case key of
@@ -1527,7 +1527,7 @@ data ButtonEvent
     | ButtonShift
     | ButtonControl
     | ButtonAlt
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 withMouseEventMask :: (MonadIO m) => [ButtonEvent] -> m a -> m a
 withAllMouseEvents :: (MonadIO m) => m a -> m a


### PR DESCRIPTION
Having `Ord` instances for these types permits applications such as having them as `Map` keys (my use case), `Set` elements, and so on.  So I think it's worth deriving `Ord`, which exacts almost no cost.